### PR TITLE
Add resolutions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
   },
   "devDependencies": {
     "@openzeppelin/contracts": "^4.5.0"
+  },
+  "resolutions": {
+    "node-fetch": "3.2.1",
+    "marked": "4.0.12"
   }
 }


### PR DESCRIPTION
- Add resolutions to package.json to force specific package versions
- Force secure package versions for indirect depedencies marked and node-fetch
- Add preinstall script to force resolutions
